### PR TITLE
close clean failed task in the state updater

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -737,7 +737,7 @@ public class TaskManager {
                 .forEach(removedTaskResult -> {
                     if (removedTaskResult.exception().isPresent()) {
                         final RuntimeException runtimeException = removedTaskResult.exception().get();
-                        if (runtimeException instanceof InvalidOffsetException) {
+                        if (runtimeException instanceof TaskCorruptedException) {
                             tasksToCloseDirtyFromStateUpdater.add(removedTaskResult.task());
                         } else  {
                             tasksToCloseCleanFromStateUpdater.add(removedTaskResult.task());
@@ -1566,7 +1566,7 @@ public class TaskManager {
             }
             for (final StateUpdater.ExceptionAndTask exceptionAndTask : stateUpdater.drainExceptionsAndFailedTasks()) {
                 final Task failedTask = exceptionAndTask.task();
-                if (exceptionAndTask.exception() instanceof InvalidOffsetException) {
+                if (exceptionAndTask.exception() instanceof TaskCorruptedException) {
                     closeTaskDirty(failedTask, false);
                 } else {
                     tasks.addTask(failedTask);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidOffsetException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
@@ -731,15 +732,20 @@ public class TaskManager {
                                    final Set<Task> tasksToCloseCleanFromStateUpdater,
                                    final Set<Task> tasksToCloseDirtyFromStateUpdater) {
         futures.entrySet().stream()
-            .map(entry -> waitForFuture(entry.getKey(), entry.getValue()))
-            .filter(Objects::nonNull)
-            .forEach(removedTaskResult -> {
-                if (removedTaskResult.exception().isPresent()) {
-                    tasksToCloseDirtyFromStateUpdater.add(removedTaskResult.task());
-                } else {
-                    tasksToCloseCleanFromStateUpdater.add(removedTaskResult.task());
-                }
-            });
+                .map(entry -> waitForFuture(entry.getKey(), entry.getValue()))
+                .filter(Objects::nonNull)
+                .forEach(removedTaskResult -> {
+                    if (removedTaskResult.exception().isPresent()) {
+                        final RuntimeException runtimeException = removedTaskResult.exception().get();
+                        if (runtimeException instanceof InvalidOffsetException) {
+                            tasksToCloseDirtyFromStateUpdater.add(removedTaskResult.task());
+                        } else  {
+                            tasksToCloseCleanFromStateUpdater.add(removedTaskResult.task());
+                        }
+                    } else {
+                        tasksToCloseCleanFromStateUpdater.add(removedTaskResult.task());
+                    }
+                });
     }
 
     private Task checkIfTaskFailed(final StateUpdater.RemovedTaskResult removedTaskResult,
@@ -1560,7 +1566,11 @@ public class TaskManager {
             }
             for (final StateUpdater.ExceptionAndTask exceptionAndTask : stateUpdater.drainExceptionsAndFailedTasks()) {
                 final Task failedTask = exceptionAndTask.task();
-                closeTaskDirty(failedTask, false);
+                if (exceptionAndTask.exception() instanceof InvalidOffsetException) {
+                    closeTaskDirty(failedTask, false);
+                } else {
+                    tasks.addTask(failedTask);
+                }
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidOffsetException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.metrics.KafkaMetric;
@@ -446,7 +447,7 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldRemoveUnusedFailedActiveTaskFromStateUpdaterAndCloseDirty() {
+    public void shouldRemoveUnusedFailedActiveTaskFromStateUpdaterAndCloseClean() {
         final StreamTask activeTaskToClose = statefulTask(taskId03, taskId03ChangelogPartitions)
             .inState(State.RESTORING)
             .withInputPartitions(taskId03Partitions).build();
@@ -459,9 +460,8 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(Collections.emptyMap(), Collections.emptyMap());
 
-        verify(activeTaskToClose).prepareCommit();
         verify(activeTaskToClose).suspend();
-        verify(activeTaskToClose).closeDirty();
+        verify(activeTaskToClose).closeClean();
         verify(activeTaskCreator).createTasks(consumer, Collections.emptyMap());
         verify(standbyTaskCreator).createTasks(Collections.emptyMap());
     }
@@ -487,7 +487,7 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldRemoveUnusedFailedStandbyTaskFromStateUpdaterAndCloseDirty() {
+    public void shouldRemoveUnusedFailedStandbyTaskFromStateUpdaterAndCloseClean() {
         final StandbyTask standbyTaskToClose = standbyTask(taskId02, taskId02ChangelogPartitions)
             .inState(State.RUNNING)
             .withInputPartitions(taskId02Partitions).build();
@@ -500,9 +500,8 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(Collections.emptyMap(), Collections.emptyMap());
 
-        verify(standbyTaskToClose).prepareCommit();
         verify(standbyTaskToClose).suspend();
-        verify(standbyTaskToClose).closeDirty();
+        verify(standbyTaskToClose).closeClean();
         verify(activeTaskCreator).createTasks(consumer, Collections.emptyMap());
         verify(standbyTaskCreator).createTasks(Collections.emptyMap());
     }
@@ -1529,10 +1528,10 @@ public class TaskManagerTest {
         final TaskManager taskManager = setupForRevocationAndLost(Set.of(task1, task2), tasks);
         final CompletableFuture<StateUpdater.RemovedTaskResult> future1 = new CompletableFuture<>();
         when(stateUpdater.remove(task1.id())).thenReturn(future1);
-        future1.complete(new StateUpdater.RemovedTaskResult(task1, new StreamsException("Something happened")));
+        future1.complete(new StateUpdater.RemovedTaskResult(task1, new InvalidOffsetException("Something happened")));
         final CompletableFuture<StateUpdater.RemovedTaskResult> future3 = new CompletableFuture<>();
         when(stateUpdater.remove(task2.id())).thenReturn(future3);
-        future3.complete(new StateUpdater.RemovedTaskResult(task2, new StreamsException("Something else happened")));
+        future3.complete(new StateUpdater.RemovedTaskResult(task2, new InvalidOffsetException("Something else happened")));
 
         taskManager.handleLostAll();
 
@@ -1569,9 +1568,8 @@ public class TaskManagerTest {
 
         verify(task1).suspend();
         verify(task1).closeClean();
-        verify(task2).prepareCommit();
         verify(task2).suspend();
-        verify(task2).closeDirty();
+        verify(task2).closeClean();
         verify(task3).suspend();
         verify(task3).closeClean();
     }
@@ -3511,7 +3509,7 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldShutDownStateUpdaterAndCloseDirtyTasksFailedDuringRemoval() {
+    public void shouldShutDownStateUpdaterAndCleanDirtyTasksFailedDuringRemoval() {
         final TasksRegistry tasks = mock(TasksRegistry.class);
         final StreamTask removedStatefulTask = statefulTask(taskId01, taskId01ChangelogPartitions)
             .inState(State.RESTORING).build();
@@ -3534,6 +3532,20 @@ public class TaskManagerTest {
                 removedFailedStatefulTaskDuringRemoval,
                 removedFailedStandbyTaskDuringRemoval
             ));
+        when(tasks.allTasks())
+                .thenReturn(Set.of(
+                        removedStatefulTask,
+                        removedStandbyTask,
+                        removedFailedStatefulTask,
+                        removedFailedStandbyTask,
+                        removedFailedStatefulTaskDuringRemoval,
+                        removedFailedStandbyTaskDuringRemoval
+                ));
+        when(tasks.activeTasks()).thenReturn(Set.of(
+                removedStatefulTask,
+                removedFailedStatefulTask,
+                removedFailedStatefulTaskDuringRemoval
+        ));
         final CompletableFuture<StateUpdater.RemovedTaskResult> futureForRemovedStatefulTask = new CompletableFuture<>();
         final CompletableFuture<StateUpdater.RemovedTaskResult> futureForRemovedStandbyTask = new CompletableFuture<>();
         final CompletableFuture<StateUpdater.RemovedTaskResult> futureForRemovedFailedStatefulTask = new CompletableFuture<>();
@@ -3569,18 +3581,16 @@ public class TaskManagerTest {
         verify(stateUpdater).shutdown(Duration.ofMillis(Long.MAX_VALUE));
         verify(tasks).addTask(removedStatefulTask);
         verify(tasks).addTask(removedStandbyTask);
-        verify(removedFailedStatefulTask).prepareCommit();
+        verify(tasks).addTask(removedFailedStatefulTask);
+        verify(tasks).addTask(removedFailedStandbyTask);
         verify(removedFailedStatefulTask).suspend();
-        verify(removedFailedStatefulTask).closeDirty();
-        verify(removedFailedStandbyTask).prepareCommit();
+        verify(removedFailedStatefulTask).closeClean();
         verify(removedFailedStandbyTask).suspend();
-        verify(removedFailedStandbyTask).closeDirty();
-        verify(removedFailedStatefulTaskDuringRemoval).prepareCommit();
+        verify(removedFailedStandbyTask).closeClean();
         verify(removedFailedStatefulTaskDuringRemoval).suspend();
-        verify(removedFailedStatefulTaskDuringRemoval).closeDirty();
-        verify(removedFailedStandbyTaskDuringRemoval).prepareCommit();
+        verify(removedFailedStatefulTaskDuringRemoval).closeClean();
         verify(removedFailedStandbyTaskDuringRemoval).suspend();
-        verify(removedFailedStandbyTaskDuringRemoval).closeDirty();
+        verify(removedFailedStandbyTaskDuringRemoval).closeClean();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -1528,10 +1528,10 @@ public class TaskManagerTest {
         final TaskManager taskManager = setupForRevocationAndLost(Set.of(task1, task2), tasks);
         final CompletableFuture<StateUpdater.RemovedTaskResult> future1 = new CompletableFuture<>();
         when(stateUpdater.remove(task1.id())).thenReturn(future1);
-        future1.complete(new StateUpdater.RemovedTaskResult(task1, new InvalidOffsetException("Something happened")));
+        future1.complete(new StateUpdater.RemovedTaskResult(task1, new TaskCorruptedException(Set.of(task1.id()))));
         final CompletableFuture<StateUpdater.RemovedTaskResult> future3 = new CompletableFuture<>();
         when(stateUpdater.remove(task2.id())).thenReturn(future3);
-        future3.complete(new StateUpdater.RemovedTaskResult(task2, new InvalidOffsetException("Something else happened")));
+        future3.complete(new StateUpdater.RemovedTaskResult(task2, new TaskCorruptedException(Set.of(task2.id()))));
 
         taskManager.handleLostAll();
 


### PR DESCRIPTION
Tasks that are registered in the state updater could raise an exception during the restoration process, for example a consumer timeout exception, a task corrupted, or any other StreamsException causing a dirty close and state store wipeouts. This PR aims to only cause a dirty close upon TaskCorruptedException detection by StateUpdater; any other exception will cause a clean close on the task.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
