### PR TITLE
fix(streams): avoid fencing during rebalance

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -45,7 +45,7 @@ import static org.apache.kafka.streams.state.internals.WrappedStateStore.isVersi
  */
 final class StateManagerUtil {
     static final String CHECKPOINT_FILE_NAME = ".checkpoint";
-    static final long OFFSET_DELTA_THRESHOLD_FOR_CHECKPOINT = 10_000L;
+    static final long OFFSET_DELTA_THRESHOLD_FOR_CHECKPOINT = 1_000_000L;
 
     private StateManagerUtil() {}
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1458,13 +1458,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     @Override
     public void onAssignment(final Assignment assignment, final ConsumerGroupMetadata metadata) {
-        taskManager.commit(
-            taskManager.allOwnedTasks()
-                .values()
-                .stream()
-                .filter(t -> t.commitNeeded())
-                .collect(Collectors.toSet())
-        );
+        Set<Task> tasksWithOpenTransactions = taskManager.allOwnedTasks()
+            .values()
+            .stream()
+            .filter(t -> t.commitNeeded())
+            .collect(Collectors.toSet());
+        log.info("Committing {} tasks with open transactions before onAssignment()", tasksWithOpenTransactions.size());
+        taskManager.commit(tasksWithOpenTransactions);
 
         final List<TopicPartition> partitions = new ArrayList<>(assignment.partitions());
         partitions.sort(PARTITION_COMPARATOR);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1458,6 +1458,14 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     @Override
     public void onAssignment(final Assignment assignment, final ConsumerGroupMetadata metadata) {
+        taskManager.commit(
+            taskManager.allOwnedTasks()
+                .values()
+                .stream()
+                .filter(t -> t.commitNeeded())
+                .collect(Collectors.toSet())
+        );
+
         final List<TopicPartition> partitions = new ArrayList<>(assignment.partitions());
         partitions.sort(PARTITION_COMPARATOR);
 


### PR DESCRIPTION
- Commit all committable tasks in the start of the onAssignment() method, which can help prevent transaction timeouts when blocking on the State Updater to release tasks
- Increase the flush threshold for tasks in the state updater to 1M records (not 10k) in order to reduce thrashing of rocksdb in background I/O.